### PR TITLE
Pass per-request API keys, improve streaming resilience and image generation

### DIFF
--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -19,6 +19,12 @@ import type {
 
 const router = Router()
 
+function getRequestKeys(req: Request) {
+  const anthropic = typeof req.headers['x-anthropic-key'] === 'string' ? req.headers['x-anthropic-key'] : undefined
+  const fal = typeof req.headers['x-fal-key'] === 'string' ? req.headers['x-fal-key'] : undefined
+  return { anthropic, fal }
+}
+
 // ── Common API error translator ───────────────────────────────────
 function apiError(err: unknown): string {
   const msg = String(err)
@@ -89,9 +95,10 @@ router.post('/config', async (req: Request, res: Response) => {
 // ================================================================
 // POST /api/world/generate — Step 1: Generate world only
 // ================================================================
-router.post('/world/generate', async (_req: Request, res: Response) => {
+router.post('/world/generate', async (req: Request, res: Response) => {
   try {
-    const world = await claude.generateWorld()
+    const { anthropic: anthropicKey } = getRequestKeys(req)
+    const world = await claude.generateWorld(anthropicKey)
     console.log(`[API] World created: ${world.name}`)
     saveWorld(world).catch(() => {})
     res.json({ world })
@@ -108,7 +115,8 @@ router.post('/npcs/generate', async (req: Request, res: Response) => {
   const { world } = req.body as { world: WorldData }
   if (!world) return res.status(400).json({ error: 'world required' })
   try {
-    const npcs = await claude.generateNPCs(world)
+    const { anthropic: anthropicKey } = getRequestKeys(req)
+    const npcs = await claude.generateNPCs(world, anthropicKey)
     console.log(`[API] NPCs created: ${npcs.length}`)
     saveNPCs(npcs).catch(() => {})
     res.json({ npcs })
@@ -125,7 +133,8 @@ router.post('/narrative/generate', async (req: Request, res: Response) => {
   const { world } = req.body as { world: WorldData }
   if (!world) return res.status(400).json({ error: 'world required' })
   try {
-    const narrative = await claude.generateNarrative(world)
+    const { anthropic: anthropicKey } = getRequestKeys(req)
+    const narrative = await claude.generateNarrative(world, anthropicKey)
     console.log('[API] Narrative created')
     saveNarrative(narrative).catch(() => {})
     res.json({ narrative })
@@ -142,7 +151,8 @@ router.post('/map/generate', async (req: Request, res: Response) => {
   const { world } = req.body as { world: WorldData }
   if (!world) return res.status(400).json({ error: 'world required' })
   try {
-    const mapImageUrl = await imageService.generateMapImage(world.name, world.lore, world.continents)
+    const { fal: falKey } = getRequestKeys(req)
+    const mapImageUrl = await imageService.generateMapImage(world.name, world.lore, world.continents, falKey)
     res.json({ mapImageUrl })
   } catch (err) {
     console.error('[API] Map generation error:', err)
@@ -153,11 +163,12 @@ router.post('/map/generate', async (req: Request, res: Response) => {
 // ================================================================
 // POST /api/game/init — (kept for compatibility) Full init in one call
 // ================================================================
-router.post('/game/init', async (_req: Request, res: Response) => {
+router.post('/game/init', async (req: Request, res: Response) => {
   try {
-    const world = await claude.generateWorld()
-    const npcs = await claude.generateNPCs(world)
-    const narrative = await claude.generateNarrative(world)
+    const { anthropic: anthropicKey } = getRequestKeys(req)
+    const world = await claude.generateWorld(anthropicKey)
+    const npcs = await claude.generateNPCs(world, anthropicKey)
+    const narrative = await claude.generateNarrative(world, anthropicKey)
     res.json({ world, npcs, narrative })
   } catch (err) {
     console.error('[API] Init error:', err)
@@ -180,7 +191,8 @@ router.post('/character/backgrounds', async (req: Request, res: Response) => {
   }
 
   try {
-    const backgrounds = await claude.generateCharacterBackgrounds(characterClass, worldName, worldLore)
+    const { anthropic: anthropicKey } = getRequestKeys(req)
+    const backgrounds = await claude.generateCharacterBackgrounds(characterClass, worldName, worldLore, anthropicKey)
     res.json({ backgrounds })
   } catch (err) {
     console.error('[API] Background generation error:', err)
@@ -221,7 +233,8 @@ router.post('/session/create', async (req: Request, res: Response) => {
   }
 
   try {
-    const initialResponse = await claude.generateInitialScene(worldData, narrative, character)
+    const { anthropic: anthropicKey, fal: falKey } = getRequestKeys(req)
+    const initialResponse = await claude.generateInitialScene(worldData, narrative, character, anthropicKey)
     const heroApp = buildHeroAppearance(character)
     const sceneImageUrl = await imageService.generateEnhancedSceneImage(
       initialResponse.scene_description,
@@ -229,7 +242,8 @@ router.post('/session/create', async (req: Request, res: Response) => {
       [],  // 초기 장면엔 아직 NPC 없음
       heroApp,
       initialResponse.current_location,
-      initialResponse.weather
+      initialResponse.weather,
+      falKey
     )
 
     res.json({
@@ -281,10 +295,19 @@ router.post('/game/action/stream', async (req: Request, res: Response) => {
     res.write(`data: ${JSON.stringify(data)}\n\n`)
   }
 
+  const heartbeat = setInterval(() => {
+    sendEvent({ type: 'heartbeat', ts: Date.now() })
+  }, 5000)
+
+  req.on('close', () => {
+    clearInterval(heartbeat)
+  })
+
   try {
+    const { anthropic: anthropicKey, fal: falKey } = getRequestKeys(req)
     const gen = claude.processGameActionStream(
       worldData, npcs ?? [], narrative ?? '',
-      character, history ?? [], input, currentLocation ?? ''
+      character, history ?? [], input, currentLocation ?? '', anthropicKey
     )
 
     let response = null
@@ -361,6 +384,7 @@ router.post('/game/action/stream', async (req: Request, res: Response) => {
     const pendingTasks: Promise<void>[] = []
 
     if (sceneImagePending) {
+      sendEvent({ type: 'status', stage: 'scene_image_generating', message: '장면 이미지를 생성하고 있습니다.' })
       // 현재 장면에 있는 NPC 객체를 찾아 외모 데이터를 이미지 프롬프트에 포함
       const sceneNpcs = (response.available_npcs ?? [])
         .map((id: string) => allNpcs.find(n => n.id === id))
@@ -374,7 +398,8 @@ router.post('/game/action/stream', async (req: Request, res: Response) => {
           sceneNpcs,
           heroApp,
           response.current_location ?? currentLocation,
-          response.weather ?? currentWeather
+          response.weather ?? currentWeather,
+          falKey
         )
           .then(url => { sendEvent({ type: 'image', sceneImageUrl: url, sceneTag }) })
           .catch(err => {
@@ -385,19 +410,23 @@ router.post('/game/action/stream', async (req: Request, res: Response) => {
     }
 
     if (pendingPortrait) {
+      sendEvent({ type: 'status', stage: 'portrait_generating', message: 'NPC 초상화를 생성하고 있습니다.' })
       const { npc, emotion, emotionDesc } = pendingPortrait
       pendingTasks.push(
-        imageService.generateNpcEmotion(npc, emotion, emotionDesc)
+        imageService.generateNpcEmotion(npc, emotion, emotionDesc, falKey)
           .then(url => { sendEvent({ type: 'portrait', npcId: npc.id, emotion, portraitUrl: url }) })
           .catch(err => { console.error('[Portrait] Generation failed:', err) })
       )
     }
 
     await Promise.all(pendingTasks)
+    sendEvent({ type: 'complete' })
+    clearInterval(heartbeat)
     res.end()
   } catch (err) {
     console.error('[API] Game action stream error:', err)
     sendEvent({ type: 'error', error: apiError(err) })
+    clearInterval(heartbeat)
     res.end()
   }
 })
@@ -427,6 +456,7 @@ router.post('/game/action', async (req: Request, res: Response) => {
   }
 
   try {
+    const { anthropic: anthropicKey, fal: falKey } = getRequestKeys(req)
     const response = await claude.processGameAction(
       worldData,
       npcs ?? [],
@@ -460,7 +490,8 @@ router.post('/game/action', async (req: Request, res: Response) => {
         sceneNpcs,
         heroApp,
         response.current_location ?? currentLocation,
-        response.weather ?? currentWeather
+        response.weather ?? currentWeather,
+        falKey
       )
       console.log(`[Image] Generated new scene: ${sceneTag}`)
     }
@@ -484,7 +515,7 @@ router.post('/game/action', async (req: Request, res: Response) => {
         } else {
           const emotionDesc = npc.emotions.find(e => e.emotion === emotion)?.description
             ?? npc.emotions[0]?.description ?? 'neutral expression'
-          portraitUrl = await imageService.generateNpcEmotion(npc, emotion, emotionDesc)
+          portraitUrl = await imageService.generateNpcEmotion(npc, emotion, emotionDesc, falKey)
           console.log(`[Image] Generated NPC portrait: ${cacheKey}`)
         }
 

--- a/server/services/claude.service.ts
+++ b/server/services/claude.service.ts
@@ -21,9 +21,10 @@ export function getAnthropicApiKey(): string | undefined {
   return _apiKey
 }
 
-function getClient(): Anthropic {
-  if (!_apiKey) throw new Error('ANTHROPIC_API_KEY가 설정되지 않았습니다. 설정에서 API 키를 입력해주세요.')
-  return new Anthropic({ apiKey: _apiKey })
+function getClient(apiKeyOverride?: string): Anthropic {
+  const key = apiKeyOverride ?? _apiKey
+  if (!key) throw new Error('ANTHROPIC_API_KEY가 설정되지 않았습니다. 설정에서 API 키를 입력해주세요.')
+  return new Anthropic({ apiKey: key })
 }
 
 export async function testApiKey(key: string): Promise<boolean> {
@@ -84,10 +85,10 @@ function parseJson<T>(text: string, pattern: RegExp, context: string): T {
 // ================================================================
 // 1. WORLD GENERATION
 // ================================================================
-export async function generateWorld(): Promise<WorldData> {
+export async function generateWorld(apiKeyOverride?: string): Promise<WorldData> {
   console.log('[Claude] Generating world...')
 
-  const msg = await getClient().messages.create({
+  const msg = await getClient(apiKeyOverride).messages.create({
     model: 'claude-sonnet-4-6',
     max_tokens: 2000,
     system: `당신은 판타지 세계를 창조하는 전문 작가입니다.
@@ -146,12 +147,12 @@ export async function generateWorld(): Promise<WorldData> {
 // ================================================================
 // 2. NPC GENERATION
 // ================================================================
-export async function generateNPCs(world: WorldData): Promise<NPC[]> {
+export async function generateNPCs(world: WorldData, apiKeyOverride?: string): Promise<NPC[]> {
   console.log('[Claude] Generating NPCs...')
 
   const kingdomsList = world.continents.flatMap(c => c.majorKingdoms).join(', ')
 
-  const msg = await getClient().messages.create({
+  const msg = await getClient(apiKeyOverride).messages.create({
     model: 'claude-sonnet-4-6',
     max_tokens: 8000,
     system: `당신은 판타지 캐릭터를 설계하는 전문 작가입니다.
@@ -203,10 +204,10 @@ JSON 배열 형식 (정확히 10명):
 // ================================================================
 // 3. NARRATIVE GENERATION
 // ================================================================
-export async function generateNarrative(world: WorldData): Promise<string> {
+export async function generateNarrative(world: WorldData, apiKeyOverride?: string): Promise<string> {
   console.log('[Claude] Generating narrative...')
 
-  const msg = await getClient().messages.create({
+  const msg = await getClient(apiKeyOverride).messages.create({
     model: 'claude-sonnet-4-6',
     max_tokens: 2000,
     system: `당신은 판타지 소설의 나레이터입니다.
@@ -243,7 +244,8 @@ export async function generateNarrative(world: WorldData): Promise<string> {
 export async function generateCharacterBackgrounds(
   characterClass: CharacterClass,
   worldName: string,
-  worldLore: string
+  worldLore: string,
+  apiKeyOverride?: string
 ): Promise<BackgroundOption[]> {
   console.log('[Claude] Generating character backgrounds...')
 
@@ -258,7 +260,7 @@ export async function generateCharacterBackgrounds(
     '팔라딘': '정의와 빛을 위해 싸우는 성스러운 기사',
   }
 
-  const msg = await getClient().messages.create({
+  const msg = await getClient(apiKeyOverride).messages.create({
     model: 'claude-sonnet-4-6',
     max_tokens: 1500,
     system: `반드시 유효한 JSON만 반환하세요. 설명 없이 순수 JSON 배열만 출력하세요.`,
@@ -358,9 +360,10 @@ const GM_JSON_FORMAT = `{
 // 예: ["검을 뽑는다||적에게 선제 공격을 가함", "도망친다||뒤를 돌아 전력으로 달림"]
 
 // visual_direction 규칙:
-// - camera_shot 기본값: 특별한 이유 없으면 "bust-up" 또는 "full-body" 사용
+// - camera_shot 기본값: 특별한 이유 없으면 "bust-up" 또는 "waist-up" 사용 (인물 얼굴 가독성 우선)
 // - "close-up"은 오직 intensity가 "climax"일 때만 허용 (일반 대화·일상 장면에서 클로즈업 금지)
-// - focus: 장소 이동/탐험 시 "environment", 전투/감정 폭발 시 "character", 은밀한 대화 시 "intimate"
+// - focus 기본값은 "character". scene-image-container는 인물 중심 구도로 유지
+// - 장소 이동/탐험 시에만 "environment" 사용, 그 외는 "character" 또는 "intimate" 우선
 // - intensity: 일상/대화="routine", 긴장/갈등="dramatic", 절정/전투클라이맥스="climax"
 
 // time_of_day/weather 규칙: 매 턴 반드시 채워야 함. 세계의 시간 흐름을 자연스럽게 유지.
@@ -605,7 +608,8 @@ export async function processGameAction(
   character: PlayerCharacter,
   history: GameMessage[],
   playerInput: string,
-  currentLocation: string
+  currentLocation: string,
+  apiKeyOverride?: string
 ): Promise<ClaudeGameResponse> {
   console.log('[Claude] Processing game action...')
 
@@ -622,7 +626,7 @@ ${GM_JSON_FORMAT}
 
 ${NEW_NPC_RULES}`
 
-  const msg = await getClient().messages.create({
+  const msg = await getClient(apiKeyOverride).messages.create({
     model: selectModel(playerInput, history),
     max_tokens: 5000,
     system: [{ type: 'text', text: buildSystemPrompt(world, npcs, narrative, character, currentLocation), cache_control: { type: 'ephemeral' } }] as any,
@@ -648,7 +652,8 @@ export async function* processGameActionStream(
   character: PlayerCharacter,
   history: GameMessage[],
   playerInput: string,
-  currentLocation: string
+  currentLocation: string,
+  apiKeyOverride?: string
 ): AsyncGenerator<StreamEvent> {
   const historyText = buildHistoryText(history)
 
@@ -663,7 +668,7 @@ ${GM_JSON_FORMAT}
 
 ${NEW_NPC_RULES}`
 
-  const stream = getClient().messages.stream({
+  const stream = getClient(apiKeyOverride).messages.stream({
     model: selectModel(playerInput, history),
     max_tokens: 5000,
     system: [{ type: 'text', text: buildSystemPrompt(world, npcs, narrative, character, currentLocation), cache_control: { type: 'ephemeral' } }] as any,
@@ -721,11 +726,12 @@ ${NEW_NPC_RULES}`
 export async function generateInitialScene(
   world: WorldData,
   narrative: string,
-  character: PlayerCharacter
+  character: PlayerCharacter,
+  apiKeyOverride?: string
 ): Promise<ClaudeGameResponse> {
   console.log('[Claude] Generating initial scene...')
 
-  const msg = await getClient().messages.create({
+  const msg = await getClient(apiKeyOverride).messages.create({
     model: 'claude-sonnet-4-6',
     max_tokens: 3000,
     system: `당신은 판타지 TRPG의 게임 마스터입니다.

--- a/server/services/image.service.ts
+++ b/server/services/image.service.ts
@@ -64,10 +64,10 @@ function placeholderDataUrl(type: 'map' | 'portrait' | 'scene', label: string): 
 // ---------- Main Image Generation Functions (stateless - no file I/O) ----------
 
 // 💡 비주얼 노벨/애니메이션 스타일에 최적화
-const SDXL_PREFIX = "(masterpiece, best quality, highres:1.2), visual novel CG art style, 2d anime illustration, vibrant cinematic lighting, flat color, clear outlines, NSFW, uncensored";
+const SDXL_PREFIX = "(masterpiece, best quality, highres:1.2), visual novel CG art style, 2d anime illustration, vibrant cinematic lighting, flat color, clear outlines, safe fantasy artwork";
 
 // 💡 실사풍/기괴한 인체 방지
-const ANIMAGINE_NEGATIVE = "(worst quality, low quality, normal quality:1.4), (realistic, photorealistic, 3d, lip, nose:1.3), bad anatomy, bad hands, missing fingers, extra digit, ugly, deformed, text, error, blurry, monochrome";
+const ANIMAGINE_NEGATIVE = "(worst quality, low quality, normal quality:1.4), (realistic, photorealistic, 3d, lip, nose:1.3), bad anatomy, bad face, asymmetrical eyes, malformed mouth, bad hands, missing fingers, extra digit, ugly, deformed, text, watermark, error, blurry, monochrome, duplicate body";
 
 function determineComposition(description: string): string {
   const desc = description.toLowerCase();
@@ -88,9 +88,10 @@ function determineComposition(description: string): string {
 export async function generateMapImage(
   worldName: string,
   _worldLore: string,
-  continents: Array<{ name: string }>
+  continents: Array<{ name: string }>,
+  falKeyOverride?: string
 ): Promise<string> {
-  const falKey = process.env.FAL_KEY
+  const falKey = falKeyOverride ?? process.env.FAL_KEY
   if (!falKey) {
     return placeholderDataUrl('map', worldName)
   }
@@ -153,9 +154,10 @@ export async function generateNpcPortrait(
 export async function generateNpcEmotion(
   npc: { name: string; appearance: string; gender: string },
   emotion: string,
-  emotionDescription: string
+  emotionDescription: string,
+  falKeyOverride?: string
 ): Promise<string> {
-  const falKey = process.env.FAL_KEY
+  const falKey = falKeyOverride ?? process.env.FAL_KEY
   if (!falKey) {
     return placeholderDataUrl('portrait', `${npc.name}\n(${emotion})`)
   }
@@ -173,7 +175,7 @@ export async function generateNpcEmotion(
     }
 
     const genderWord = npc.gender === '여성' ? 'female' : 'male'
-    const prompt = `${SDXL_PREFIX}bust portrait, fantasy character, ${genderWord}, ${npc.appearance}, EXACTLY same character appearance and outfit, ${emotionMap[emotion] ?? emotion}, ${emotionDescription}, consistent character design, visual novel character art style, clean background`
+    const prompt = `${SDXL_PREFIX}bust portrait, fantasy character, ${genderWord}, ${npc.appearance}, EXACTLY same character appearance and outfit, ${emotionMap[emotion] ?? emotion}, ${emotionDescription}, centered face, symmetrical facial features, detailed eyes, clean lineart, consistent character design, visual novel character art style, clean background`
 
     const result = await fal.subscribe('fal-ai/animagine-xl-v3-1', {
       input: {
@@ -284,9 +286,10 @@ export async function generateEnhancedSceneImage(
   activeNpcs?: NPC[],
   heroAppearance?: string,
   currentLocation?: string,
-  weather?: string
+  weather?: string,
+  falKeyOverride?: string
 ): Promise<string> {
-  const falKey = process.env.FAL_KEY
+  const falKey = falKeyOverride ?? process.env.FAL_KEY
   if (!falKey) return placeholderDataUrl('scene', sceneDescription.slice(0, 40))
 
   try {
@@ -297,7 +300,7 @@ export async function generateEnhancedSceneImage(
     if (activeNpcs && activeNpcs.length > 0) {
       const targetNpcs = activeNpcs.slice(0, 2);
       npcAppearance = targetNpcs.map(n => `(${n.appearance}:1.1)`).join(', ');
-      const personCount = targetNpcs.length === 1 ? "1girl/1boy, solo" : "2girls/2boys/1girl 1boy, multiple characters";
+      const personCount = targetNpcs.length === 1 ? "solo character, portrait framing" : "2 characters maximum, character-focused framing";
       npcAppearance = `${personCount}, ${npcAppearance}`;
     }
 
@@ -310,7 +313,9 @@ export async function generateEnhancedSceneImage(
       ? SHOT_COMPOSITION[direction.camera_shot]
       : determineComposition(sceneDescription)
 
-    const focusTags   = direction?.focus    ? FOCUS_TAGS[direction.focus]    : 'medium shot, protagonist visible, cinematic composition'
+    const focusTags   = direction?.focus
+      ? FOCUS_TAGS[direction.focus]
+      : 'character-centric composition, protagonist clearly visible, face details preserved, cinematic composition'
     const lightingTag = direction?.lighting ? direction.lighting + ' lighting' : 'cinematic atmospheric lighting'
 
     // ── 중요도에 따른 품질 차별화 ──
@@ -331,6 +336,7 @@ export async function generateEnhancedSceneImage(
       focusTags,
       heroAppearance ? `protagonist: ${heroAppearance}` : '',
       npcAppearance  ? `characters: ${npcAppearance}`   : '',
+      'main subject in foreground, readable face, clean anatomy',
       intensityTag,
     ].filter(Boolean)
 

--- a/src/components/GameScreen.tsx
+++ b/src/components/GameScreen.tsx
@@ -327,7 +327,7 @@ function StatsBar() {
 
 // ── Main GameScreen ───────────────────────────────────
 export default function GameScreen() {
-  const { messages, npcs, sendAction, isProcessing, streamingContent, suggestedActions, error, resetGame } = useGameStore()
+  const { messages, npcs, sendAction, isProcessing, streamingContent, suggestedActions, error, resetGame, currentScene, streamStatus, responseTruncated } = useGameStore()
   const [input, setInput] = useState('')
   const [showMenu, setShowMenu] = useState(false)
   const [showInfoPanel, setShowInfoPanel] = useState(false)
@@ -367,6 +367,7 @@ export default function GameScreen() {
 
   const DEFAULT_ACTIONS = ['주변을 살펴본다', '앞으로 나아간다', '누군가에게 말을 건다', '현재 상황을 파악한다']
   const quickActions = suggestedActions.length > 0 ? suggestedActions : DEFAULT_ACTIONS
+  const sceneBackdrop = currentScene?.imageUrl
 
   return (
     <div className="flex flex-col h-screen" style={{ background: '#05050a' }}>
@@ -453,8 +454,19 @@ export default function GameScreen() {
         </div>
 
         {/* Messages + Input column — flex-col keeps input aligned with messages */}
-        <div className="flex-1 flex flex-col overflow-hidden">
-        <div className="flex-1 overflow-y-auto">
+        <div className="flex-1 flex flex-col overflow-hidden relative">
+        {sceneBackdrop && (
+          <div className="absolute inset-0 pointer-events-none"
+            style={{
+              backgroundImage: `linear-gradient(rgba(5,5,10,0.83), rgba(5,5,10,0.95)), url(${sceneBackdrop})`,
+              backgroundSize: 'cover',
+              backgroundPosition: 'center',
+              filter: 'blur(1px)',
+              opacity: 0.45,
+            }}
+          />
+        )}
+        <div className="flex-1 overflow-y-auto relative">
         <div className="px-4 py-4 space-y-6" style={{ maxWidth: '780px', margin: '0 auto' }}>
 
           {messages.map(msg => (
@@ -478,6 +490,14 @@ export default function GameScreen() {
             </div>
           )}
 
+          {isProcessing && streamStatus && (
+            <div className="flex items-center gap-3 animate-fade-in">
+              <div className="fantasy-panel rounded-sm px-4 py-2 text-xs" style={{ color: 'rgba(180,166,130,0.8)' }}>
+                ⏳ {streamStatus}
+              </div>
+            </div>
+          )}
+
           {/* Spinner — shows before first chunk arrives */}
           {isProcessing && !streamingContent && (
             <div className="flex items-center gap-3 animate-fade-in">
@@ -487,6 +507,13 @@ export default function GameScreen() {
                   게임 마스터가 이야기를 쓰는 중...
                 </span>
               </div>
+            </div>
+          )}
+
+          {responseTruncated && !error && (
+            <div className="fantasy-panel rounded-sm p-3 text-sm text-center"
+              style={{ borderColor: 'rgba(212,175,55,0.45)', color: 'rgba(232,213,176,0.82)' }}>
+              응답이 중간에 종료되었습니다. 같은 행동을 다시 보내면 이어서 진행됩니다.
             </div>
           )}
 

--- a/src/components/NarrativeScreen.tsx
+++ b/src/components/NarrativeScreen.tsx
@@ -37,7 +37,7 @@ function TypewriterText({ text, speed = 25, onDone }: { text: string; speed?: nu
 }
 
 export default function NarrativeScreen() {
-  const { narrative, world, setPhase } = useGameStore()
+  const { narrative, world, mapImageUrl, setPhase } = useGameStore()
   const [paragraphs, setParagraphs] = useState<string[]>([])
   const [visibleParagraphs, setVisibleParagraphs] = useState<number>(0)
   const [allDone, setAllDone] = useState(false)
@@ -95,8 +95,19 @@ export default function NarrativeScreen() {
       </div>
 
       {/* Narrative container */}
-      <div ref={containerRef}
-        className="flex-1 overflow-y-auto px-4 md:px-8 pb-8 max-w-3xl mx-auto w-full">
+      <div className="flex-1 overflow-y-auto relative" ref={containerRef}>
+        {mapImageUrl && (
+          <div className="absolute inset-0 pointer-events-none"
+            style={{
+              backgroundImage: `linear-gradient(rgba(6,6,10,0.84), rgba(6,6,10,0.95)), url(${mapImageUrl})`,
+              backgroundSize: 'cover',
+              backgroundPosition: 'center',
+              opacity: 0.4,
+            }}
+          />
+        )}
+
+        <div className="px-4 md:px-8 pb-8 max-w-3xl mx-auto w-full relative">
 
         <div className="fantasy-panel rounded-sm p-8 md:p-12 relative">
           <div className="corner-ornament top-left" />
@@ -143,6 +154,7 @@ export default function NarrativeScreen() {
             </div>
           )}
         </div>
+      </div>
       </div>
 
       {/* Action buttons */}

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -55,13 +55,13 @@ function getInitialStats(characterClass: CharacterClass): CharacterStats {
 // ─── Server session helpers ───────────────────────────────────
 async function saveSessionToServer(session: GameSession) {
   try {
-    await axios.post('/api/session/save', { session }, { timeout: 15000 })
+    await axios.post('/api/session/save', { session }, { timeout: 15000, headers: buildApiHeaders() })
   } catch (err) {
     console.warn('[Save] 서버 저장 실패 (로컬 저장은 유지됨):', err instanceof Error ? err.message : err)
     // Retry once after 3s
     setTimeout(async () => {
       try {
-        await axios.post('/api/session/save', { session }, { timeout: 15000 })
+        await axios.post('/api/session/save', { session }, { timeout: 15000, headers: buildApiHeaders() })
       } catch { /* 2nd attempt failed — local save is primary */ }
     }, 3000)
   }
@@ -79,6 +79,8 @@ const LS_NPCS = 'fantasy-ai-npcs'
 const LS_NARRATIVE = 'fantasy-ai-narrative'
 const LS_SESSIONS = 'fantasy-ai-sessions'
 const LS_LAST_SESSION = 'fantasy-ai-last-session'
+const LS_ANTHROPIC_KEY = 'fantasy-ai-anthropic-key'
+const LS_FAL_KEY = 'fantasy-ai-fal-key'
 
 function lsGet<T>(key: string): T | null {
   try {
@@ -99,6 +101,15 @@ function lsSet(key: string, value: unknown) {
 
 function lsDel(key: string) {
   try { localStorage.removeItem(key) } catch { /* ignore */ }
+}
+
+function buildApiHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {}
+  const anthropicKey = lsGet<string>(LS_ANTHROPIC_KEY)
+  const falKey = lsGet<string>(LS_FAL_KEY)
+  if (anthropicKey) headers['x-anthropic-key'] = anthropicKey
+  if (falKey) headers['x-fal-key'] = falKey
+  return headers
 }
 
 // ─── Safe error message extraction ────────────────────────────
@@ -171,6 +182,8 @@ interface GameStore {
   streamingContent: string
   suggestedActions: string[]
   error: string | null
+  streamStatus: string | null
+  responseTruncated: boolean
 
   hasApiKey: boolean
   savedSessions: SessionSummary[]
@@ -186,6 +199,7 @@ interface GameStore {
   sendAction: (input: string) => Promise<void>
   resetGame: () => Promise<void>
   setError: (err: string | null) => void
+  clearStreamFlags: () => void
   saveApiKey: (anthropicKey: string, falKey?: string) => Promise<void>
   loadSessions: () => void
   loadServerSessions: () => Promise<void>
@@ -220,6 +234,8 @@ export const useGameStore = create<GameStore>((set, get) => ({
   streamingContent: '',
   suggestedActions: [],
   error: null,
+  streamStatus: null,
+  responseTruncated: false,
 
   hasApiKey: false,
   savedSessions: [],
@@ -231,7 +247,9 @@ export const useGameStore = create<GameStore>((set, get) => ({
   saveApiKey: async (anthropicKey: string, falKey?: string) => {
     set({ error: null })
     try {
-      await axios.post('/api/config', { anthropicApiKey: anthropicKey, falKey }, { timeout: 30000 })
+      lsSet(LS_ANTHROPIC_KEY, anthropicKey)
+      if (falKey) lsSet(LS_FAL_KEY, falKey)
+      await axios.post('/api/config', { anthropicApiKey: anthropicKey, falKey }, { timeout: 30000, headers: buildApiHeaders() })
       set({ hasApiKey: true })
     } catch (err: unknown) {
       throw new Error(extractMessage(err))
@@ -257,7 +275,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
   // ── Load sessions from server (cross-device) ────────────
   loadServerSessions: async () => {
     try {
-      const res = await axios.get('/api/sessions', { timeout: 5000 })
+      const res = await axios.get('/api/sessions', { timeout: 5000, headers: buildApiHeaders() })
       const serverSessions: SessionSummary[] = res.data.sessions ?? []
       if (serverSessions.length === 0) return
 
@@ -414,9 +432,9 @@ export const useGameStore = create<GameStore>((set, get) => ({
     if (!world) {
       try {
         const [worldRes, npcsRes, narrativeRes] = await Promise.all([
-          axios.get('/api/world', { timeout: 5000 }),
-          axios.get('/api/npcs', { timeout: 5000 }),
-          axios.get('/api/narrative', { timeout: 5000 }),
+          axios.get('/api/world', { timeout: 5000, headers: buildApiHeaders() }),
+          axios.get('/api/npcs', { timeout: 5000, headers: buildApiHeaders() }),
+          axios.get('/api/narrative', { timeout: 5000, headers: buildApiHeaders() }),
         ])
         if (worldRes.data.world) {
           world = worldRes.data.world as WorldData
@@ -494,7 +512,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
     axios.post('/api/quests/generate', {
       worldName: world?.name ?? '',
       character: { name: data.name, characterClass: data.characterClass, backstory: data.backstory },
-    }, { timeout: 30000 }).then(res => {
+    }, { timeout: 30000, headers: buildApiHeaders() }).then(res => {
       const quests: Quest[] = res.data.quests ?? []
       set({ quests })
     }).catch(() => {})
@@ -505,7 +523,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
         ...data,
         worldData: world,
         narrative,
-      }, { timeout: 90000 })
+      }, { timeout: 90000, headers: buildApiHeaders() })
       const { initialNarration, sceneImageUrl, currentLocation } = res.data
 
       const firstMessage: GameMessage = {
@@ -558,7 +576,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
     } = get()
     if (!world || !character) return
 
-    set({ isProcessing: true, streamingContent: '', error: null })
+    set({ isProcessing: true, streamingContent: '', error: null, streamStatus: '응답을 준비 중...', responseTruncated: false })
 
     const playerMsg: GameMessage = {
       id: `msg_${Date.now()}_player`,
@@ -578,7 +596,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
       try {
         const res = await fetch('/api/game/action/stream', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Content-Type': 'application/json', ...buildApiHeaders() },
           signal: controller.signal,
           body: JSON.stringify({
             worldData: world,
@@ -602,12 +620,19 @@ export const useGameStore = create<GameStore>((set, get) => ({
         }
 
       const reader = res.body!.getReader()
+      let receivedDone = false
+      let receivedChunk = false
       const decoder = new TextDecoder()
       let sseBuffer = ''
 
       const processEvent = (data: Record<string, unknown>) => {
         if (data.type === 'chunk') {
-          set(state => ({ streamingContent: state.streamingContent + (data.content as string) }))
+          receivedChunk = true
+          set(state => ({ streamingContent: state.streamingContent + (data.content as string), streamStatus: '이야기를 생성 중...' }))
+        } else if (data.type === 'status') {
+          set({ streamStatus: String((data as { message?: string }).message ?? '처리 중...') })
+        } else if (data.type === 'heartbeat') {
+          set(state => ({ streamStatus: state.streamStatus ?? '응답을 기다리는 중...' }))
         } else if (data.type === 'image') {
           // Async scene image arrived after 'done'
           const { sceneImageUrl: imageUrl, sceneTag: tag } = data as { sceneImageUrl: string | null; sceneTag: string }
@@ -645,6 +670,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
             }
           })
         } else if (data.type === 'done') {
+          receivedDone = true
           const {
             narration, summary, sceneImageUrl, sceneImagePending: imagePending, sceneTag,
             currentLocation: newLoc, timeOfDay: newTimeOfDay, weather: newWeather,
@@ -805,6 +831,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
             weather: updatedWeather,
             isProcessing: false,
             streamingContent: '',
+            streamStatus: imagePending ? '텍스트 응답 완료 · 이미지 생성 중...' : null,
             ...(updatedCharacter !== prevChar ? { character: updatedCharacter } : {}),
             ...(gameOver ? { phase: 'start' } : {}),
           })
@@ -844,6 +871,8 @@ export const useGameStore = create<GameStore>((set, get) => ({
               get().loadSessions()
             }
           }
+        } else if (data.type === 'complete') {
+          set({ streamStatus: null })
         } else if (data.type === 'error') {
           throw new Error(data.error as string)
         }
@@ -851,7 +880,10 @@ export const useGameStore = create<GameStore>((set, get) => ({
 
       while (true) {
         const { done, value } = await reader.read()
-        if (done) break
+        if (done) {
+          sseBuffer += decoder.decode()
+          break
+        }
         sseBuffer += decoder.decode(value, { stream: true })
         const parts = sseBuffer.split('\n\n')
         sseBuffer = parts.pop() ?? ''
@@ -863,13 +895,46 @@ export const useGameStore = create<GameStore>((set, get) => ({
           }
         }
       }
+
+      // 마지막 버퍼에 남은 SSE 이벤트도 파싱 (서버가 직전 프레임에서 종료될 수 있음)
+      if (sseBuffer.trim()) {
+        for (const line of sseBuffer.split('\n')) {
+          if (line.startsWith('data: ')) {
+            try { processEvent(JSON.parse(line.slice(6))) } catch { /* skip malformed */ }
+          }
+        }
+      }
+
+      if (!receivedDone) {
+        const partialText = get().streamingContent.trim()
+        if (receivedChunk && partialText) {
+          const fallbackMsg: GameMessage = {
+            id: `msg_${Date.now()}_response_partial`,
+            role: 'narrator',
+            content: partialText,
+            timestamp: Date.now(),
+          }
+          set(state => ({
+            messages: [...state.messages, fallbackMsg],
+            isProcessing: false,
+            responseTruncated: true,
+            streamingContent: '',
+            streamStatus: null,
+            error: '응답이 중간에 끊겨 임시 텍스트를 표시했습니다. 이어서 다시 시도해주세요.',
+          }))
+          return
+        }
+
+        set({ responseTruncated: true, streamStatus: null })
+        throw new Error('응답이 중간에 종료되었습니다. 이어서 다시 시도해주세요.')
+      }
       } catch (innerErr: unknown) {
         clearTimeout(timeoutId)
         const isAbort = innerErr instanceof DOMException && innerErr.name === 'AbortError'
         const isNetwork = innerErr instanceof TypeError && innerErr.message.includes('fetch')
         if ((isAbort || isNetwork) && attempt < MAX_RETRIES) {
           const delay = 1500 * (attempt + 1)
-          set({ streamingContent: '', error: null })
+          set({ streamingContent: '', error: null, streamStatus: '재연결 중...' })
           await new Promise(r => setTimeout(r, delay))
           return attemptStream(attempt + 1)
         }
@@ -882,7 +947,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
     } catch (err: unknown) {
       const isAbort = err instanceof DOMException && err.name === 'AbortError'
       const msg = isAbort ? '응답 시간이 초과되었습니다. 다시 시도해주세요.' : `행동 처리 실패: ${extractMessage(err)}`
-      set({ error: msg, isProcessing: false, streamingContent: '' })
+      set({ error: msg, isProcessing: false, streamingContent: '', streamStatus: null })
     }
   },
 
@@ -891,7 +956,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
     set({ isLoading: true, error: null })
     try {
       // Session data is critical — fetch it first
-      const sessionRes = await axios.get(`/api/session/${sessionId}`, { timeout: 15000 })
+      const sessionRes = await axios.get(`/api/session/${sessionId}`, { timeout: 15000, headers: buildApiHeaders() })
       const session: GameSession = sessionRes.data.session
 
       // Reuse already-loaded world/npcs/narrative if available (avoids redundant cross-device fetches)
@@ -902,9 +967,9 @@ export const useGameStore = create<GameStore>((set, get) => ({
 
       // Fetch only missing pieces — individually so one failure doesn't block the others
       const [worldRes, npcsRes, narrativeRes] = await Promise.all([
-        world   ? Promise.resolve(null) : axios.get('/api/world',     { timeout: 15000 }).catch(() => null),
-        npcs    ? Promise.resolve(null) : axios.get('/api/npcs',      { timeout: 15000 }).catch(() => null),
-        narrative ? Promise.resolve(null) : axios.get('/api/narrative', { timeout: 15000 }).catch(() => null),
+        world   ? Promise.resolve(null) : axios.get('/api/world',     { timeout: 15000, headers: buildApiHeaders() }).catch(() => null),
+        npcs    ? Promise.resolve(null) : axios.get('/api/npcs',      { timeout: 15000, headers: buildApiHeaders() }).catch(() => null),
+        narrative ? Promise.resolve(null) : axios.get('/api/narrative', { timeout: 15000, headers: buildApiHeaders() }).catch(() => null),
       ])
 
       if (!world && worldRes)       world = worldRes.data.world ?? null
@@ -951,7 +1016,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
 
     // Remove from server
     try {
-      await axios.delete(`/api/session/${sessionId}`, { timeout: 5000 })
+      await axios.delete(`/api/session/${sessionId}`, { timeout: 5000, headers: buildApiHeaders() })
     } catch { /* ignore — local deletion is enough */ }
 
     // If this was the last session, clear that reference too
@@ -972,7 +1037,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
       character: null, backgroundOptions: [],
       sessionId: null, messages: [], currentLocation: '',
       currentScene: null, quests: [], sceneImageCache: {}, npcPortraitCache: {},
-      timeOfDay: null, weather: null, error: null,
+      timeOfDay: null, weather: null, error: null, streamStatus: null, responseTruncated: false,
     })
   },
 }))


### PR DESCRIPTION
### Motivation
- Allow clients to provide their own Anthropic and FAL keys per request so API usage can be delegated without changing server env vars. 
- Make SSE game-action streaming more robust and informative with heartbeat/status events and clearer handling when responses are truncated. 
- Improve image generation prompts and safety negatives for more reliable and readable character/scene outputs. 

### Description
- Add header-based key overrides by reading `x-anthropic-key` and `x-fal-key` in `server/routes/api.ts` and propagate them to service calls using a new `getRequestKeys` helper. 
- Update Claude service to accept an optional `apiKeyOverride` via `getClient(apiKeyOverride)` and thread that override through all generation functions (`generateWorld`, `generateNPCs`, `generateNarrative`, `generateCharacterBackgrounds`, `generateInitialScene`, `processGameAction`, `processGameActionStream`). 
- Make image service accept `falKeyOverride` for `generateMapImage`, `generateNpcEmotion`, and `generateEnhancedSceneImage`, and refine prompts and negative prompts (`SDXL_PREFIX`, `ANIMAGINE_NEGATIVE`, composition/focus improvements). 
- Improve SSE handling in `game/action/stream` by emitting periodic `heartbeat` events, sending `status` updates for image/portrait generation, ensuring cleanup on client close, and sending a final `complete` event; client now parses these, shows `streamStatus`, and falls back to a partial message when streaming terminates early (`responseTruncated`). 
- Client-side changes: store per-key values in localStorage (`LS_ANTHROPIC_KEY`, `LS_FAL_KEY`), add `buildApiHeaders()` to attach `x-anthropic-key`/`x-fal-key` to API requests, display scene/map backdrops in `GameScreen` and `NarrativeScreen`, and show streaming status and truncated-response notices in the UI. 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0e76465c4832a95c7fdffa41cd6a9)