### PR TITLE
Fix VisualDirection type for initial scene image endpoint

### DIFF
--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -15,6 +15,7 @@ import type {
   CharacterClass,
   PlayerCharacter,
   GameMessage,
+  VisualDirection,
 } from '../../src/types/game'
 
 const router = Router()
@@ -259,7 +260,7 @@ router.post('/session/create', async (req: Request, res: Response) => {
 router.post('/session/initial-image', async (req: Request, res: Response) => {
   const { sceneDescription, visualDirection, currentLocation, weather, character } = req.body as {
     sceneDescription: string
-    visualDirection?: string | null
+    visualDirection?: VisualDirection | null
     currentLocation?: string
     weather?: string | null
     character?: PlayerCharacter


### PR DESCRIPTION
### Motivation
- Ensure the `/api/session/initial-image` route uses the correct `VisualDirection` type so passing `visualDirection` into `imageService.generateEnhancedSceneImage` does not cause a TypeScript mismatch (TS2345).

### Description
- Import `VisualDirection` from `../../src/types/game` and update the request body typing in the `/session/initial-image` handler from `visualDirection?: string | null` to `visualDirection?: VisualDirection | null`.

### Testing
- Ran `npm run build:server`; the build failed in this container due to missing type/dependency declarations (e.g. `@types/node`, `@types/express`, and `@fal-ai/client`), but the original `visualDirection` type mismatch addressed by this patch is fixed in the code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a146c11f68832ab2c29b4aa57012ab)