### PR TITLE
Handle incomplete SSE action streams and fallback to partial responses

### DIFF
--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -658,12 +658,15 @@ export const useGameStore = create<GameStore>((set, get) => ({
 
       const reader = res.body!.getReader()
       let receivedDone = false
+      let streamedText = ''
       const decoder = new TextDecoder()
       let sseBuffer = ''
 
       const processEvent = (data: Record<string, unknown>) => {
         if (data.type === 'chunk') {
-          set(state => ({ streamingContent: state.streamingContent + (data.content as string), streamStatus: '이야기를 생성 중...' }))
+          const chunk = data.content as string
+          streamedText += chunk
+          set(state => ({ streamingContent: state.streamingContent + chunk, streamStatus: '이야기를 생성 중...' }))
         } else if (data.type === 'status') {
           set({ streamStatus: String((data as { message?: string }).message ?? '처리 중...') })
         } else if (data.type === 'heartbeat') {
@@ -938,6 +941,48 @@ export const useGameStore = create<GameStore>((set, get) => ({
       flushSseParts([sseBuffer])
 
       if (!receivedDone) {
+        if (attempt < MAX_RETRIES) {
+          throw new Error('STREAM_INCOMPLETE')
+        }
+
+        const partialText = streamedText.trim()
+        if (partialText) {
+          const fallbackResponseMsg: GameMessage = {
+            id: `msg_${Date.now()}_response_partial`,
+            role: 'narrator',
+            content: partialText,
+            summary: '응답 스트림이 중단되어 부분 응답을 표시했습니다.',
+            timestamp: Date.now(),
+          }
+
+          const newMessages = [...get().messages, fallbackResponseMsg]
+          set({
+            messages: newMessages,
+            isProcessing: false,
+            streamingContent: '',
+            streamStatus: null,
+            responseTruncated: true,
+            error: null,
+          })
+
+          if (sessionId) {
+            const sessions = lsGet<Record<string, GameSession>>(LS_SESSIONS) ?? {}
+            const existing = sessions[sessionId]
+            if (existing) {
+              const updatedSession = {
+                ...existing,
+                messages: newMessages,
+                updatedAt: Date.now(),
+              }
+              sessions[sessionId] = updatedSession
+              lsSet(LS_SESSIONS, sessions)
+              saveSessionToServer(updatedSession)
+              get().loadSessions()
+            }
+          }
+          return
+        }
+
         set({ responseTruncated: true, streamStatus: null })
         throw new Error('응답이 중간에 종료되었습니다. 이어서 다시 시도해주세요.')
       }
@@ -945,7 +990,8 @@ export const useGameStore = create<GameStore>((set, get) => ({
         clearTimeout(timeoutId)
         const isAbort = innerErr instanceof DOMException && innerErr.name === 'AbortError'
         const isNetwork = innerErr instanceof TypeError && innerErr.message.includes('fetch')
-        if ((isAbort || isNetwork) && attempt < MAX_RETRIES) {
+        const isIncompleteStream = innerErr instanceof Error && innerErr.message === 'STREAM_INCOMPLETE'
+        if ((isAbort || isNetwork || isIncompleteStream) && attempt < MAX_RETRIES) {
           const delay = 1500 * (attempt + 1)
           set({ streamingContent: '', error: null, streamStatus: '재연결 중...' })
           await new Promise(r => setTimeout(r, delay))


### PR DESCRIPTION
### Motivation
- Users experienced frequent `행동 처리 실패` / `응답이 중단되었습니다` when the SSE connection closed before the final `done` event, causing lost text and a poor UX.
- The goal is to make the client resilient to transient stream interruptions and preserve any partial narration when possible.

### Description
- Accumulate incoming SSE `chunk` text into a new `streamedText` buffer while still updating `streamingContent` for live display in `src/store/gameStore.ts`.
- When the stream finishes without a `done` event, throw a `STREAM_INCOMPLETE` on early retries to trigger the existing retry logic and allow reconnects before failing.
- On the last retry, if partial text was received, create a fallback partial `GameMessage` and persist it into the current in-memory messages and session storage instead of hard-failing.
- Treat `STREAM_INCOMPLETE` as a retryable condition alongside aborts and network errors to reduce transient failures.

### Testing
- Attempted to run full build with `npm run build:all`, but the environment failed with `sh: 1: vite: not found` so build verification could not complete.
- Ran dependency installation attempts (`npm ci` / `npm install`) which showed environment warnings and did not produce a usable `vite` binary in this runtime, preventing full build/test.
- Confirmed the modified file `src/store/gameStore.ts` was updated and committed (`git commit`) successfully.
- No automated unit tests were available or executed in this environment; behaviour verified through static inspection and simulated reasoning about SSE flow changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a15681d034832aac6f010f05528f92)