### PR TITLE
Improve narrative background fill behavior on mobile

### DIFF
--- a/src/components/NarrativeScreen.tsx
+++ b/src/components/NarrativeScreen.tsx
@@ -80,8 +80,21 @@ export default function NarrativeScreen() {
   }
 
   return (
-    <div className="min-h-screen flex flex-col"
+    <div
+      className="relative min-h-[100dvh] flex flex-col overflow-hidden"
       style={{ background: 'radial-gradient(ellipse at top, #0f0a1a 0%, #0a0a0f 70%)' }}>
+
+      {mapImageUrl && (
+        <div
+          className="absolute inset-0 pointer-events-none"
+          style={{
+            backgroundImage: `linear-gradient(rgba(6,6,10,0.8), rgba(6,6,10,0.95)), url(${mapImageUrl})`,
+            backgroundSize: 'cover',
+            backgroundPosition: 'center',
+            opacity: 0.45,
+          }}
+        />
+      )}
 
       {/* Header */}
       <div className="text-center pt-10 pb-6 px-4">
@@ -96,16 +109,6 @@ export default function NarrativeScreen() {
 
       {/* Narrative container */}
       <div className="flex-1 overflow-y-auto relative" ref={containerRef}>
-        {mapImageUrl && (
-          <div className="absolute inset-0 pointer-events-none"
-            style={{
-              backgroundImage: `linear-gradient(rgba(6,6,10,0.84), rgba(6,6,10,0.95)), url(${mapImageUrl})`,
-              backgroundSize: 'cover',
-              backgroundPosition: 'center',
-              opacity: 0.4,
-            }}
-          />
-        )}
 
         <div className="px-4 md:px-8 pb-8 max-w-3xl mx-auto w-full relative">
 


### PR DESCRIPTION
### Motivation
- Ensure the narrative screen's background image fills the visible mobile viewport (including header and bottom actions) so the map backdrop reads as a full-screen background instead of being clipped to the scroll area.
- Prepare the UI so pre-generated / cached background images can be used reliably across mobile and desktop viewports.

### Description
- Updated `src/components/NarrativeScreen.tsx` root container to use `relative min-h-[100dvh] flex flex-col overflow-hidden` so the container matches viewport height on mobile.
- Moved the `mapImageUrl` background layer out of the scrollable content and rendered it as an `absolute inset-0` layer at the root level with the same gradient overlay, adjusting overlay opacity for readability.
- Removed the duplicate background block from inside the scroll region and simplified the structure so header/body/footer display consistently over the backdrop.
- Kept existing gradient + cover/center settings and adjusted opacity to `0.45` for the root background layer.

### Testing
- Attempted `npm run build` which failed in this environment with `vite: not found` so a local build could not be validated automatically.
- Ran `npm install` / `npm ci` attempts which encountered environment/registry constraints and dependency resolution warnings, preventing a clean local install in this environment.
- Tried a Playwright screenshot against a dev server but it failed with `ERR_EMPTY_RESPONSE` because the dev server was not running here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a159b438d4832aaef18f6ae9b3b430)