### PR TITLE
Add imagePrompt support for initial scene generation

### DIFF
--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -255,6 +255,7 @@ router.post('/session/create', async (req: Request, res: Response) => {
       sceneImagePending: true,
       initialScene: {
         sceneDescription: initialResponse.scene_description,
+        imagePrompt: initialResponse.image_prompt ?? null,
         visualDirection: initialResponse.visual_direction ?? null,
       },
     })
@@ -268,8 +269,9 @@ router.post('/session/create', async (req: Request, res: Response) => {
 // POST /api/session/initial-image — Generate initial scene image async
 // ================================================================
 router.post('/session/initial-image', async (req: Request, res: Response) => {
-  const { sceneDescription, visualDirection, currentLocation, weather, character } = req.body as {
+  const { sceneDescription, imagePrompt, visualDirection, currentLocation, weather, character } = req.body as {
     sceneDescription: string
+    imagePrompt?: string | null
     visualDirection?: VisualDirection | null
     currentLocation?: string
     weather?: string | null
@@ -284,16 +286,18 @@ router.post('/session/initial-image', async (req: Request, res: Response) => {
   try {
     const { fal: falKey } = getRequestKeys(req)
     const heroApp = buildHeroAppearance(character)
-    const sceneImageUrl = getLocationImageUrl(currentLocation ?? '') 
+    const sceneImageUrl = getLocationImageUrl(currentLocation ?? '')
       ?? await imageService.generateEnhancedSceneImage(
           sceneDescription, visualDirection ?? null, [], heroApp,
-          currentLocation, weather ?? undefined, falKey
+          currentLocation, weather ?? undefined, falKey,
+          imagePrompt ?? undefined
         )
 
     res.json({ sceneImageUrl })
   } catch (err) {
     console.error('[API] Initial image generation error:', err)
-    res.status(500).json({ error: apiError(err) })
+    // 이미지 생성 실패 시 500 대신 null URL 반환 — 클라이언트가 gracefully 처리
+    res.json({ sceneImageUrl: null })
   }
 })
 

--- a/server/services/claude.service.ts
+++ b/server/services/claude.service.ts
@@ -820,7 +820,7 @@ export async function generateInitialScene(
 
   const msg = await getClient(apiKeyOverride).messages.create({
     model: 'claude-sonnet-4-6',
-    max_tokens: 3000,
+    max_tokens: 4096,
     system: `당신은 판타지 TRPG의 게임 마스터입니다.
 반드시 유효한 JSON만 반환하세요.`,
     messages: [

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -538,6 +538,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
         sceneImagePending?: boolean
         initialScene?: {
           sceneDescription: string
+          imagePrompt?: string | null
           visualDirection?: string | null
         }
       }
@@ -582,6 +583,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
       if (initialScene?.sceneDescription) {
         axios.post('/api/session/initial-image', {
           sceneDescription: initialScene.sceneDescription,
+          imagePrompt: initialScene.imagePrompt ?? null,
           visualDirection: initialScene.visualDirection ?? null,
           currentLocation,
           weather: weather ?? null,


### PR DESCRIPTION
## Summary
This PR adds support for passing an `imagePrompt` field through the initial scene generation pipeline, allowing more precise control over the generated scene image. The prompt is now captured from the Claude API response and propagated through to the image generation service.

## Key Changes
- **API Route (`/session/initial-image`)**: Added `imagePrompt` parameter to request body and passed it to the image generation service
- **Claude Service**: Increased `max_tokens` from 3000 to 4096 to accommodate the additional `image_prompt` field in responses
- **Game Store**: Updated the `initialScene` type definition to include optional `imagePrompt` field and pass it when requesting initial image generation
- **Error Handling**: Changed initial image generation error response from HTTP 500 to gracefully returning `null` URL, allowing the client to handle missing images without hard failures

## Implementation Details
- The `imagePrompt` is optional and defaults to `null` if not provided by the Claude API
- The field flows through the entire pipeline: Claude response → session creation → image generation request
- Image generation failures now return a successful response with `sceneImageUrl: null` rather than an error status, enabling more graceful client-side handling

https://claude.ai/code/session_01SgMfGQK1Ynb4jASUnBut3x